### PR TITLE
Fix ExecutionListenerHelper

### DIFF
--- a/flyway-test-extensions/flyway-spring-test/src/main/java/org/flywaydb/test/ExecutionListenerHelper.java
+++ b/flyway-test-extensions/flyway-spring-test/src/main/java/org/flywaydb/test/ExecutionListenerHelper.java
@@ -43,7 +43,15 @@ public abstract class ExecutionListenerHelper {
 		result = testClass.getName();
 
 		// now check for method
-		Method m = testContext.getTestMethod();
+		Method m = null;
+
+		try {
+			m = testContext.getTestMethod();
+		}
+		catch (IllegalStateException ex) {
+			// Do Nothing
+		}
+
 		if (m != null) {
 			result = result + "." + m.getName();
 		}

--- a/flyway-test-extensions/flyway-spring5-test/pom.xml
+++ b/flyway-test-extensions/flyway-spring5-test/pom.xml
@@ -29,7 +29,7 @@
             <dependency>
                 <groupId>org.springframework</groupId>
                 <artifactId>spring-framework-bom</artifactId>
-                <version>5.0.0.RC1</version>
+                <version>5.0.0.RC3</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>


### PR DESCRIPTION
Previous to spring version 5.0.0.RC2 TestContext#getTestMethod()
returned null. Now, it returns an IllegalStateException.

See gh-33